### PR TITLE
Proposed update to the WPF documentation

### DIFF
--- a/source/wpfintegration.rst
+++ b/source/wpfintegration.rst
@@ -2,55 +2,84 @@
 Windows Presentation Foundation Integration Guide
 =================================================
 
+WPF accepts constructor parameters by default. Therefore dependency injection can be done
+quite simple. By making some tiny adjustments to the Visual Studio default template
+Simple Injector is up and running in no time.
+
 The first step is to properly configure the *App.xaml* markup:
 
 .. code-block:: xaml
 
     <Application x:Class="SimpleInjectorWPF.App"
                  xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-                 xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-                 Startup="Application_Startup">
-        <!-- Remove the StartupUri property, replace with Startup event handler -->
+                 xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+        <!-- Remove the StartupUri property, start the application from a static void Main -->
         <Application.Resources>
          
         </Application.Resources>
     </Application>
 
-Then *App.xaml.cs* will need to be modified to allow for registration:
+Then add a *Program.cs* file to your project as entry point for the application:
 
 .. code-block:: c#
 
+    using System;
     using System.Windows;
     using SimpleInjector;
 
-    public partial class App : Application {
-        private static Container container;
+    static class Program
+    {
+        [STAThread]
+        static void Main()
+        {
+            // Create a simple injector container and do needed registrations
+            // before we start the application
+            // Starting the application before calling `Verify()` on the container
+            // will result in directly stopping the application due to default
+            // behaviour of the System.Windows.Application class
+            var container = Bootstrap();
 
-        private void Application_Startup(object sender, StartupEventArgs e) {
-            Bootstrap();
-            
-            var window = container.GetInstance<MainWindow>();
-            
-            // Initialize window here, or register an initializer in the 'Bootstrap' method.
-            //
-            
-            window.Show();
+            // possible other configuration, e.g. of your desired MVVM toolkit
+
+            RunApplication(container);
         }
 
-        private static void Bootstrap() {
+        private static Container Bootstrap()
+        {
             // Create the container as usual.
-            container = new Container();
+            var container = new Container();
 
             // Register your types, for instance:
             container.RegisterSingle<IUserRepository, SqlUserRepository>();
             container.Register<IUserContext, WpfUserContext>();
 
+            // Register your windows and viewmodels:
+            container.Register<MainWindow>();
+            container.Register<MainWindowViewModel>();
+
             // Optionally verify the container.
             container.Verify();
+
+            return container;
+        }
+
+        private static void RunApplication(Container container)
+        {
+            try
+            {
+                var app = new App();
+                app.Run(container.GetInstance<MainWindow>());
+            }
+            catch (Exception ex)
+            {
+                //Log the exception and exit
+            }
         }
     }
     
-Constructor injection can be used as normal on the *MainWindow* and any other windows:
+In the properties of your project, change the 'Startup object' to the newly added *Program* class.
+
+Constructor injection can be used as normal on the *MainWindow* and any other windows or viewmodels:
 
 .. code-block:: c#
 
@@ -66,15 +95,15 @@ Constructor injection can be used as normal on the *MainWindow* and any other wi
     }
 
     public class MainWindowViewModel {
-        private IUserRepository userRepository;
-        private IUserContext userContext;
-
-        public IEnumerable<IUser> Users {
-            get { return userRepository.GetAll(); }
-        }
+        private readonly IUserRepository userRepository;
+        private readonly IUserContext userContext;
 
         public MainWindowViewModel(IUserRepository userRepository, IUserContext userContext) {
             this.userRepository = userRepository;
             this.userContext = userContext;
+        }
+        
+        public IEnumerable<IUser> Users {
+            get { return userRepository.GetAll(); }
         }
     }


### PR DESCRIPTION
This was a long standing promise. I tested the proposed solution and it is working as expected. Addition of the viewmodel is actually a bonus and isn't really necessary but is in compliance with 'pushing our users in the right direction'
Adjustment made to using the startup event. When registering the windows in the container. Calling verify() will shut down the application. This is because when verfiy is called the MainWindow will be created and disposed. At disposable the 'Application' class will see an empty collection of windows, which will end the AppDomain.